### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(person("Tomas J.", "Aragon", role = "aut",
         "dwoll@psychologie.uni-kiel.de"),
         person("Adam", "Omidpanah", role = c("cre", "ctb"), email =
         "adam.omidpanah@wsu.edu"))
+URL: https://github.com/cran/epitools
 Depends: R (>= 2.10)
 Description: Tools for training and practicing epidemiologists including methods for two-way and multi-way contingency tables.
 License: GPL (>= 2)


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.
From a technical point of view, this is useful for allowing autolinking in pkgdown websites. Here is the explanation: https://pkgdown.r-lib.org/articles/linking.html?q=cross#across-packages
For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION